### PR TITLE
feat: add responsive video player component

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1,0 +1,127 @@
+const { useState, useRef, useEffect } = React;
+
+function VideoPlayer() {
+  const containerRef = useRef(null);
+  const videoRef = useRef(null);
+  const [scale, setScale] = useState(1);
+  const [hover, setHover] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const widthScale = window.innerWidth / 3840;
+      const heightScale = window.innerHeight / 2160;
+      setScale(Math.min(widthScale, heightScale));
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    const timeHandler = () => setCurrentTime(video.currentTime);
+    const loadedHandler = () => setDuration(video.duration);
+    const playHandler = () => setIsPlaying(true);
+    const pauseHandler = () => setIsPlaying(false);
+    video.addEventListener('timeupdate', timeHandler);
+    video.addEventListener('loadedmetadata', loadedHandler);
+    video.addEventListener('play', playHandler);
+    video.addEventListener('pause', pauseHandler);
+    return () => {
+      video.removeEventListener('timeupdate', timeHandler);
+      video.removeEventListener('loadedmetadata', loadedHandler);
+      video.removeEventListener('play', playHandler);
+      video.removeEventListener('pause', pauseHandler);
+    };
+  }, []);
+
+  const togglePlay = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      video.play();
+    } else {
+      video.pause();
+    }
+  };
+
+  const handleSeek = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const percent = (e.clientX - rect.left) / rect.width;
+    if (duration) {
+      videoRef.current.currentTime = percent * duration;
+    }
+  };
+
+  const handleVolume = (e) => {
+    const vol = parseFloat(e.target.value);
+    setVolume(vol);
+    if (videoRef.current) {
+      videoRef.current.volume = vol;
+    }
+  };
+
+  const formatTime = (t) => {
+    if (!isFinite(t)) return '0:00';
+    const h = Math.floor(t / 3600);
+    const m = Math.floor((t % 3600) / 60);
+    const s = Math.floor(t % 60);
+    const mm = h ? String(m).padStart(2, '0') : String(m);
+    const hh = h ? h + ':' : '';
+    const ss = String(s).padStart(2, '0');
+    return hh + mm + ':' + ss;
+  };
+
+  return (
+    React.createElement('div', {
+      className: 'player-wrapper',
+      ref: containerRef,
+      style: { width: 1840 * scale, height: 1121 * scale },
+      onMouseEnter: () => setHover(true),
+      onMouseLeave: () => setHover(false)
+    },
+      React.createElement('div', { className: 'player-inner', style: { transform: 'scale(' + scale + ')' } },
+        React.createElement('div', { className: 'video-placeholder' },
+          React.createElement('video', { ref: videoRef, src: 'https://www.w3schools.com/html/mov_bbb.mp4' }),
+          React.createElement('div', { className: 'hover-controls', style: { opacity: hover ? 1 : 0 } },
+            React.createElement('div', { className: 'controls-left' },
+              React.createElement('div', { className: 'time-elapsed' }, formatTime(currentTime)),
+              React.createElement('div', { className: 'volume-slider' },
+                React.createElement('input', {
+                  type: 'range', min: '0', max: '1', step: '0.01',
+                  value: volume, onChange: handleVolume
+                })
+              )
+            ),
+            React.createElement('div', { className: 'controls-right' },
+              React.createElement('div', { className: 'time-remaining' }, formatTime(duration - currentTime))
+            ),
+            React.createElement('div', { className: 'playbar', onClick: handleSeek },
+              React.createElement('div', {
+                className: 'playbar-elapsed',
+                style: { width: duration ? (currentTime / duration) * 1772 : 0 }
+              })
+            )
+          )
+        ),
+        React.createElement('div', { className: 'playpause', onClick: togglePlay },
+          isPlaying ?
+            React.createElement('svg', { width: '50', height: '21', viewBox: '0 0 50 21', fill: 'none', xmlns: 'http://www.w3.org/2000/svg' },
+              React.createElement('path', { d: 'M38 2V19M49 2V19', stroke: '#333333', 'stroke-width': '2', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' }),
+              React.createElement('path', { d: 'M1 18.322V2.83726C1 2.04494 1.87753 1.56731 2.54291 1.99748L15.5827 10.4276C16.2208 10.8401 16.1839 11.7853 15.51056 12.1469L2.47584 19.2016C1.80955 19.562 1 19.0796 1 18.322Z', stroke: '#333333', 'stroke-width': '2' })
+            ) :
+            React.createElement('svg', { width: '50', height: '21', viewBox: '0 0 50 21', fill: 'none', xmlns: 'http://www.w3.org/2000/svg' },
+              React.createElement('path', { d: 'M1 18.322V2.83726C1 2.04494 1.87753 1.56731 2.54291 1.99748L15.5827 10.4276C16.2208 10.8401 16.1839 11.7853 15.51056 12.1469L2.47584 19.2016C1.80955 19.562 1 19.0796 1 18.322Z', stroke: '#333333', 'stroke-width': '2' })
+            )
+        )
+      )
+    )
+  );
+}
+
+window.VideoPlayer = VideoPlayer;

--- a/index.html
+++ b/index.html
@@ -1,56 +1,19 @@
-<div data-layer="Macbook 3840x2160" class="Macbook3840x2160" style="width: 3840px; height: 2160px; position: relative; background: #E0DCD5; overflow: hidden; outline: 1px black solid; outline-offset: -1px">
-  <div data-layer="Video Player" class="VideoPlayer" style="width: 1840px; height: 1121px; left: 988px; top: 474px; position: absolute">
-    <div data-layer="Video Placeholder" class="VideoPlaceholder" style="width: 1840px; height: 1035px; left: 0px; top: 14px; position: absolute; box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); overflow: hidden; border-radius: 14px; background-image: url(https://placehold.co/1840x1035)">
-      <div data-layer="Video Hover Controls" class="VideoHoverControls" style="width: 1798px; height: 65px; left: 21px; top: 950px; position: absolute; background: rgba(85.03, 91.85, 76.10, 0.62); box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); border-radius: 13px">
-        <div data-layer="Controls Left" class="ControlsLeft" style="width: 137px; height: 15px; left: 25px; top: 14px; position: absolute">
-          <div data-layer="Time elapsed" class="TimeElapsed" style="left: 0px; top: 0px; position: absolute; color: #E0E0E0; font-size: 12px; font-family: Inter; font-weight: 400; word-wrap: break-word">10:15</div>
-          <div data-layer="Volume Slider" class="VolumeSlider" style="width: 90px; height: 8px; left: 47px; top: 6px; position: absolute">
-            <div data-svg-wrapper data-layer="area" class="Area" style="left: 57px; top: 2px; position: absolute">
-              <svg width="33" height="4" viewBox="0 0 33 4" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect width="33" height="4" rx="2" transform="matrix(1 0 0 -1 0 4)" fill="#B5A0A0"/>
-              </svg>
-            </div>
-            <div data-svg-wrapper data-layer="progress" class="Progress" style="left: 0px; top: 2px; position: absolute">
-              <svg width="59" height="4" viewBox="0 0 59 4" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect width="59" height="4" rx="2" transform="matrix(1 0 0 -1 0 4)" fill="#291F1F"/>
-              </svg>
-            </div>
-            <div data-svg-wrapper data-layer="indicator" class="Indicator" style="left: 54px; top: 0px; position: absolute">
-              <svg width="8" height="8" viewBox="0 0 8 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="4" cy="4" r="3.25" fill="#E0E0E0" stroke="#0F172A" stroke-width="1.5"/>
-              </svg>
-            </div>
-          </div>
-        </div>
-        <div data-layer="Controls Right" class="ControlsRight" style="width: 196px; height: 15px; left: 1577px; top: 14px; position: absolute">
-          <div data-svg-wrapper data-layer="Captions Icon" class="CaptionsIcon" style="left: 51px; top: 0px; position: absolute">
-            <svg width="21" height="15" viewBox="0 0 21 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12.2646 4.05425C13.308 3.53252 14.5558 3.74517 15.3803 4.56973C15.6732 4.86262 15.6732 5.3375 15.3803 5.63039C15.0874 5.92328 14.6126 5.92327 14.3197 5.63038C13.9442 5.25491 13.392 5.16759 12.9354 5.39588C12.5049 5.61115 12 6.20283 12 7.50006C12 8.79729 12.5049 9.38896 12.9354 9.60422C13.392 9.83251 13.9442 9.74518 14.3197 9.36972C14.6126 9.07683 15.0874 9.07683 15.3803 9.36972C15.6732 9.66261 15.6732 10.1375 15.3803 10.4304C14.5558 11.2549 13.308 11.4676 12.2646 10.9459C11.1951 10.4111 10.5 9.20279 10.5 7.50006C10.5 5.79733 11.1951 4.589 12.2646 4.05425ZM9.38033 4.56973C8.55579 3.74517 7.30802 3.53252 6.26458 4.05425C5.19511 4.589 4.5 5.79733 4.5 7.50006C4.5 9.20279 5.19511 10.4111 6.26459 10.9459C7.30802 11.4676 8.55579 11.2549 9.38033 10.4304C9.67322 10.1375 9.67322 9.66261 9.38033 9.36972C9.08744 9.07683 8.61256 9.07683 8.31967 9.36972C7.94421 9.74518 7.39198 9.83251 6.93541 9.60422C6.50489 9.38896 6 8.79729 6 7.50006C6 6.20283 6.50489 5.61115 6.93542 5.39588C7.39198 5.16759 7.94421 5.25491 8.31967 5.63038C8.61256 5.92327 9.08743 5.92328 9.38033 5.63039C9.67322 5.3375 9.67323 4.86262 9.38033 4.56973ZM0 3.75C0 1.67893 1.67893 0 3.75 0H17.25C19.3211 0 21 1.67893 21 3.75V11.25C21 13.3211 19.3211 15 17.25 15H3.75C1.67893 15 0 13.3211 0 11.25V3.75ZM3.75 1.5C2.50736 1.5 1.5 2.50736 1.5 3.75V11.25C1.5 12.4926 2.50736 13.5 3.75 13.5H17.25C18.4926 13.5 19.5 12.4926 19.5 11.25V3.75C19.5 2.50736 18.4926 1.5 17.25 1.5H3.75Z" fill="#E0E0E0"/>
-            </svg>
-          </div>
-          <div data-layer="Time remaining" class="TimeRemaining" style="left: 156px; top: 0px; position: absolute; color: #E0E0E0; font-size: 12px; font-family: Inter; font-weight: 400; word-wrap: break-word">1:02:15</div>
-          <div data-svg-wrapper data-layer="Airplay Icon" class="AirplayIcon" style="left: 0px; top: 1px; position: absolute">
-            <svg width="17" height="15" viewBox="0 0 17 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M3.25 11.1111H2.5C2.10218 11.1111 1.72064 10.9589 1.43934 10.688C1.15804 10.4172 1 10.0498 1 9.66667V2.44444C1 2.06135 1.15804 1.69395 1.43934 1.42307C1.72064 1.15218 2.10218 1 2.5 1H14.5C14.8978 1 15.2794 1.15218 15.5607 1.42307C15.842 1.69395 16 2.06135 16 2.44444V9.66667C16 10.0498 15.842 10.4172 15.5607 10.688C15.2794 10.9589 14.8978 11.1111 14.5 11.1111H13.75M8.5 9.66667L12.25 14H4.75L8.5 9.66667Z" stroke="#E0E0E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </div>
-          <div data-svg-wrapper data-layer="Icon" class="Icon" style="left: 108px; top: 1px; position: absolute">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M4.33333 1H2.33333C1.97971 1 1.64057 1.14048 1.39052 1.39052C1.14048 1.64057 1 1.97971 1 2.33333V4.33333M13 4.33333V2.33333C13 1.97971 12.8595 1.64057 12.6095 1.39052C12.3594 1.14048 12.0203 1 11.6667 1H9.66667M9.66667 13H11.6667C12.0203 13 12.3594 12.8595 12.6095 12.6095C12.8595 12.3594 13 12.0203 13 11.6667V9.66667M1 9.66667V11.6667C1 12.0203 1.14048 12.3594 1.39052 12.6095C1.64057 12.8595 1.97971 13 2.33333 13H4.33333" stroke="#E0E0E0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-            </svg>
-          </div>
-        </div>
-        <div data-layer="PLAYBAR" class="Playbar" style="width: 1772px; height: 8px; left: 13px; top: 43px; position: absolute; background: black; box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25); overflow: hidden; border-radius: 5px">
-          <div data-layer="VIDEO TIME Remaining" class="VideoTimeRemaining" style="width: 1430px; height: 8px; left: 342px; top: 0px; position: absolute; background: rgba(122.41, 112.22, 112.22, 0.64)"></div>
-          <div data-layer="VIDEO TIME ELAPSED" class="VideoTimeElapsed" style="width: 347px; height: 8px; left: 0px; top: 0px; position: absolute; background: #291F1F; border-top-right-radius: 5px; border-bottom-right-radius: 5px"></div>
-        </div>
-      </div>
-    </div>
-    <div data-svg-wrapper data-layer="PlayPause Buttons" class="PlaypauseButtons" style="left: 896px; top: 1088px; position: absolute">
-      <svg width="50" height="21" viewBox="0 0 50 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M38 2V19M49 2V19" stroke="#333333" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M1 18.322V2.83726C1 2.04494 1.87753 1.56731 2.54291 1.99748L15.5827 10.4276C16.2208 10.8401 16.1839 11.7853 15.5156 12.1469L2.47584 19.2016C1.80955 19.562 1 19.0796 1 18.322Z" stroke="#333333" stroke-width="2"/>
-      </svg>
-    </div>
-  </div>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Responsive Video Player</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="VideoPlayer.js"></script>
+  <script>
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(VideoPlayer));
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,135 @@
+body {
+  margin: 0;
+  background: #E0DCD5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.player-wrapper {
+  position: relative;
+}
+
+.player-inner {
+  width: 1840px;
+  height: 1121px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+}
+
+.video-placeholder {
+  width: 1840px;
+  height: 1035px;
+  left: 0;
+  top: 14px;
+  position: absolute;
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  border-radius: 14px;
+  background: black;
+}
+
+.video-placeholder video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.hover-controls {
+  width: 1798px;
+  height: 65px;
+  left: 21px;
+  top: 950px;
+  position: absolute;
+  background: rgba(85, 92, 76, 0.62);
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 13px;
+  opacity: 0;
+  transition: opacity .3s;
+}
+
+.player-wrapper:hover .hover-controls {
+  opacity: 1;
+}
+
+.controls-left {
+  width: 137px;
+  height: 15px;
+  left: 25px;
+  top: 14px;
+  position: absolute;
+}
+
+.time-elapsed {
+  left: 0;
+  top: 0;
+  position: absolute;
+  color: #E0E0E0;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+}
+
+.volume-slider {
+  width: 90px;
+  height: 8px;
+  left: 47px;
+  top: 6px;
+  position: absolute;
+}
+
+.volume-slider input {
+  width: 100%;
+}
+
+.controls-right {
+  width: 196px;
+  height: 15px;
+  right: 25px;
+  top: 14px;
+  position: absolute;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 12px;
+  box-sizing: border-box;
+}
+
+.time-remaining {
+  color: #E0E0E0;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+}
+
+.playbar {
+  width: 1772px;
+  height: 8px;
+  left: 13px;
+  top: 43px;
+  position: absolute;
+  background: black;
+  box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.playbar-elapsed {
+  height: 8px;
+  background: #291F1F;
+}
+
+.playpause {
+  left: 896px;
+  top: 1088px;
+  position: absolute;
+  cursor: pointer;
+}
+
+.playpause svg {
+  width: 50px;
+  height: 21px;
+}


### PR DESCRIPTION
## Summary
- replace static HTML with React root and mount script
- implement responsive video player with custom controls
- add responsive CSS for hover controls and layout
- adjust scaling to preserve original screen padding and widen right-side controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b60d458cc8832580aabf970f224c3d