### PR TITLE
Improve video player layout padding and control spacing

### DIFF
--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -1,6 +1,6 @@
 .video-player-wrapper {
   width: 100%;
-  max-width: 100%;
+  max-width: 1840px;
   aspect-ratio: 1840 / 1121;
   position: relative;
 }
@@ -110,7 +110,7 @@
 .controls-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 34px;
   color: #E0E0E0;
   font-size: 12px;
   font-family: Inter, sans-serif;


### PR DESCRIPTION
## Summary
- prevent video from stretching full width by limiting player wrapper to its base 1840px width
- give right-side control icons more breathing room with a wider gap

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b6190fd8c48325b8cc7b9ed08f3f69