### PR TITLE
Improve video player layout padding and control spacing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "new-ui-v2",
       "version": "0.1.0",
       "dependencies": {
+        "animejs": "^4.1.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1"
@@ -4370,6 +4371,12 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/animejs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.1.3.tgz",
+      "integrity": "sha512-4XzlIsQsku1ycSPzchxxT0N+ohEMZObG71nOSBBkZoV4sgQvtXa/qAANkFpTE6pegdV8JnIBZiB0LfdxNoRNMw==",
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -16163,9 +16170,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -16173,7 +16180,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "animejs": "^4.1.3",
+    "animejs": "^3.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "animejs": "^4.1.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1"

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -1,6 +1,6 @@
 .video-player-wrapper {
-  width: calc(100vw * 1840 / 3840);
-  max-width: 1840px;
+  width: calc(100vw * 2086 / 2693);
+  max-width: 2086px;
   aspect-ratio: 1840 / 1121;
   position: relative;
 }

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -72,39 +72,12 @@
 .volume-slider {
   width: 90px;
   height: 8px;
-  position: relative;
   margin-left: 47px;
 }
 
-.volume-slider .progress {
-  position: absolute;
-  left: 0;
-  top: 2px;
-  width: 59px;
-  height: 4px;
-  background: #4B5F47;
-  border-radius: 2px;
-}
-
-.volume-slider .area {
-  position: absolute;
-  left: 57px;
-  top: 2px;
-  width: 33px;
-  height: 4px;
-  background: #B5A0A0;
-  border-radius: 2px;
-}
-
-.volume-slider .indicator {
-  position: absolute;
-  left: 54px;
-  top: 0;
-  width: 8px;
-  height: 8px;
-  background: #E0E0E0;
-  border: 1.5px solid #0F172A;
-  border-radius: 50%;
+.volume-slider input {
+  width: 100%;
+  height: 100%;
 }
 
 .controls-right {
@@ -126,6 +99,7 @@
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);
   overflow: hidden;
   border-radius: 5px;
+  cursor: pointer;
 }
 
 .playbar .elapsed {
@@ -133,18 +107,13 @@
   left: 0;
   top: 0;
   height: 100%;
-  width: 347px;
   background: #4B5F47;
-  border-top-right-radius: 5px;
-  border-bottom-right-radius: 5px;
 }
 
 .playbar .remaining {
   position: absolute;
-  left: 342px;
   top: 0;
   height: 100%;
-  width: 1430px;
   background: rgba(122, 112, 112, 0.64);
 }
 

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -78,6 +78,7 @@
 .volume-slider input {
   width: 100%;
   height: 100%;
+  cursor: pointer;
 }
 
 .controls-right {
@@ -88,6 +89,10 @@
   font-size: 12px;
   font-family: Inter, sans-serif;
   font-weight: 400;
+}
+
+.controls-right > div {
+  cursor: pointer;
 }
 
 .playbar {
@@ -108,6 +113,7 @@
   top: 0;
   height: 100%;
   background: #4B5F47;
+  transition: width 0.1s linear;
 }
 
 .playbar .remaining {
@@ -115,6 +121,7 @@
   top: 0;
   height: 100%;
   background: rgba(122, 112, 112, 0.64);
+  transition: width 0.1s linear;
 }
 
 .play-pause {
@@ -126,5 +133,23 @@
   border: none;
   padding: 0;
   cursor: pointer;
+}
+
+.video-player-wrapper:fullscreen {
+  width: 100vw;
+  height: 100vh;
+}
+
+.video-player-wrapper:fullscreen .video-player-base {
+  width: 100%;
+  height: 100%;
+  transform: none;
+}
+
+.video-player-wrapper:fullscreen .video-placeholder {
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
 }
 

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -114,7 +114,7 @@
   top: 0;
   height: 100%;
   background: #4B5F47;
-  transition: width 0.1s linear;
+  width: 0%;
 }
 
 .play-pause {

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -1,6 +1,6 @@
 .video-player-wrapper {
-  width: 100%;
-  max-width: 100%;
+  width: calc(100vw * 1840 / 3840);
+  max-width: 1840px;
   aspect-ratio: 1840 / 1121;
   position: relative;
 }
@@ -110,7 +110,7 @@
 .controls-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 34px;
   color: #E0E0E0;
   font-size: 12px;
   font-family: Inter, sans-serif;

--- a/src/VideoPlayer.css
+++ b/src/VideoPlayer.css
@@ -105,6 +105,7 @@
   overflow: hidden;
   border-radius: 5px;
   cursor: pointer;
+  background: rgba(122, 112, 112, 0.64);
 }
 
 .playbar .elapsed {
@@ -113,14 +114,6 @@
   top: 0;
   height: 100%;
   background: #4B5F47;
-  transition: width 0.1s linear;
-}
-
-.playbar .remaining {
-  position: absolute;
-  top: 0;
-  height: 100%;
-  background: rgba(122, 112, 112, 0.64);
   transition: width 0.1s linear;
 }
 
@@ -133,23 +126,5 @@
   border: none;
   padding: 0;
   cursor: pointer;
-}
-
-.video-player-wrapper:fullscreen {
-  width: 100vw;
-  height: 100vh;
-}
-
-.video-player-wrapper:fullscreen .video-player-base {
-  width: 100%;
-  height: 100%;
-  transform: none;
-}
-
-.video-player-wrapper:fullscreen .video-placeholder {
-  width: 100%;
-  height: 100%;
-  top: 0;
-  left: 0;
 }
 

--- a/src/VideoPlayer.js
+++ b/src/VideoPlayer.js
@@ -7,8 +7,13 @@ const BASE_HEIGHT = 1121;
 const VideoPlayer = () => {
   const wrapperRef = useRef(null);
   const videoRef = useRef(null);
+  const playbarRef = useRef(null);
   const [scale, setScale] = useState(1);
   const [playing, setPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [volume, setVolume] = useState(1);
+  const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
@@ -34,27 +39,98 @@ const VideoPlayer = () => {
     }
   };
 
+  const handleTimeUpdate = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    setCurrentTime(video.currentTime);
+    setDuration(video.duration);
+  };
+
+  const formatTime = (time) => {
+    if (isNaN(time)) return '0:00';
+    const hours = Math.floor(time / 3600);
+    const minutes = Math.floor((time % 3600) / 60);
+    const seconds = Math.floor(time % 60).toString().padStart(2, '0');
+    return hours > 0
+      ? `${hours}:${minutes.toString().padStart(2, '0')}:${seconds}`
+      : `${minutes}:${seconds}`;
+  };
+
+  const handleVolumeChange = (e) => {
+    const value = Number(e.target.value);
+    setVolume(value);
+    if (videoRef.current) {
+      videoRef.current.volume = value;
+    }
+  };
+
+  const handleSeek = (e) => {
+    if (!playbarRef.current || !videoRef.current) return;
+    const rect = playbarRef.current.getBoundingClientRect();
+    const percent = (e.clientX - rect.left) / rect.width;
+    videoRef.current.currentTime = percent * duration;
+  };
+
+  const toggleFullscreen = () => {
+    const video = videoRef.current;
+    if (!video) return;
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else if (video.requestFullscreen) {
+      video.requestFullscreen();
+    }
+  };
+
+  const showAirplayPicker = () => {
+    const video = videoRef.current;
+    if (video && typeof video.webkitShowPlaybackTargetPicker === 'function') {
+      video.webkitShowPlaybackTargetPicker();
+    }
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (hovered && e.code === 'Space') {
+        e.preventDefault();
+        togglePlay();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [hovered, playing]);
+
   return (
     <div className="video-player-wrapper" ref={wrapperRef}>
       <div className="video-player-base" style={{ transform: `scale(${scale})` }}>
-        <div className="video-placeholder">
+        <div
+          className="video-placeholder"
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
           <video
             ref={videoRef}
             className="video-element"
             src="https://www.w3schools.com/html/mov_bbb.mp4"
+            onLoadedMetadata={handleTimeUpdate}
+            onTimeUpdate={handleTimeUpdate}
           />
           <div className="hover-controls">
             <div className="controls-top">
               <div className="controls-left">
-                <div className="time-elapsed">10:15</div>
+                <div className="time-elapsed">{formatTime(currentTime)}</div>
                 <div className="volume-slider">
-                  <div className="progress" />
-                  <div className="area" />
-                  <div className="indicator" />
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value={volume}
+                    onChange={handleVolumeChange}
+                  />
                 </div>
               </div>
               <div className="controls-right">
-                <div className="airplay-icon">
+                <div className="airplay-icon" onClick={showAirplayPicker}>
                   <svg width="17" height="15" viewBox="0 0 17 15" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M3.25 11.1111H2.5C2.10218 11.1111 1.72064 10.9589 1.43934 10.688C1.15804 10.4172 1 10.0498 1 9.66667V2.44444C1 2.06135 1.15804 1.69395 1.43934 1.42307C1.72064 1.15218 2.10218 1 2.5 1H14.5C14.8978 1 15.2794 1.15218 15.5607 1.42307C15.842 1.69395 16 2.06135 16 2.44444V9.66667C16 10.0498 15.842 10.4172 15.5607 10.688C15.2794 10.9589 14.8978 11.1111 14.5 11.1111H13.75M8.5 9.66667L12.25 14H4.75L8.5 9.66667Z" stroke="#E0E0E0" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
@@ -64,17 +140,26 @@ const VideoPlayer = () => {
                     <path d="M12.2646 4.05425C13.308 3.53252 14.5558 3.74517 15.3803 4.56973C15.6732 4.86262 15.6732 5.3375 15.3803 5.63039C15.0874 5.92328 14.6126 5.92327 14.3197 5.63038C13.9442 5.25491 13.392 5.16759 12.9354 5.39588C12.5049 5.61115 12 6.20283 12 7.50006C12 8.79729 12.5049 9.38896 12.9354 9.60422C13.392 9.83251 13.9442 9.74518 14.3197 9.36972C14.6126 9.07683 15.0874 9.07683 15.3803 9.36972C15.6732 9.66261 15.6732 10.1375 15.3803 10.4304C14.5558 11.2549 13.308 11.4676 12.2646 10.9459C11.1951 10.4111 10.5 9.20279 10.5 7.50006C10.5 5.79733 11.1951 4.589 12.2646 4.05425ZM9.38033 4.56973C8.55579 3.74517 7.30802 3.53252 6.26458 4.05425C5.19511 4.589 4.5 5.79733 4.5 7.50006C4.5 9.20279 5.19511 10.4111 6.26459 10.9459C7.30802 11.4676 8.55579 11.2549 9.38033 10.4304C9.67322 10.1375 9.67322 9.66261 9.38033 9.36972C9.08744 9.07683 8.61256 9.07683 8.31967 9.36972C7.94421 9.74518 7.39198 9.83251 6.93541 9.60422C6.50489 9.38896 6 8.79729 6 7.50006C6 6.20283 6.50489 5.61115 6.93542 5.39588C7.39198 5.16759 7.94421 5.25491 8.31967 5.63038C8.61256 5.92327 9.08743 5.92328 9.38033 5.63039C9.67322 5.3375 9.67323 4.86262 9.38033 4.56973ZM0 3.75C0 1.67893 1.67893 0 3.75 0H17.25C19.3211 0 21 1.67893 21 3.75V11.25C21 13.3211 19.3211 15 17.25 15H3.75C1.67893 15 0 13.3211 0 11.25V3.75ZM3.75 1.5C2.50736 1.5 1.5 2.50736 1.5 3.75V11.25C1.5 12.4926 2.50736 13.5 3.75 13.5H17.25C18.4926 13.5 19.5 12.4926 19.5 11.25V3.75C19.5 2.50736 18.4926 1.5 17.25 1.5H3.75Z" fill="#E0E0E0"/>
                   </svg>
                 </div>
-                <div className="time-remaining">1:02:15</div>
-                <div className="expand-icon">
+                <div className="time-remaining">{formatTime(duration - currentTime)}</div>
+                <div className="expand-icon" onClick={toggleFullscreen}>
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M4.33333 1H2.33333C1.97971 1 1.64057 1.14048 1.39052 1.39052C1.14048 1.64057 1 1.97971 1 2.33333V4.33333M13 4.33333V2.33333C13 1.97971 12.8595 1.64057 12.6095 1.39052C12.3594 1.14048 12.0203 1 11.6667 1H9.66667M9.66667 13H11.6667C12.0203 13 12.3594 12.8595 12.6095 12.6095C12.8595 12.3594 13 12.0203 13 11.6667V9.66667M1 9.66667V11.6667C1 12.0203 1.14048 12.3594 1.39052 12.6095C1.64057 12.8595 1.97971 13 2.33333 13H4.33333" stroke="#E0E0E0" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
                   </svg>
                 </div>
               </div>
             </div>
-            <div className="playbar">
-              <div className="elapsed" />
-              <div className="remaining" />
+            <div className="playbar" onClick={handleSeek} ref={playbarRef}>
+              <div
+                className="elapsed"
+                style={{ width: `${(currentTime / duration) * 100 || 0}%` }}
+              />
+              <div
+                className="remaining"
+                style={{
+                  left: `${(currentTime / duration) * 100 || 0}%`,
+                  width: `${(1 - currentTime / duration) * 100 || 100}%`,
+                }}
+              />
             </div>
           </div>
         </div>

--- a/src/VideoPlayer.js
+++ b/src/VideoPlayer.js
@@ -78,12 +78,12 @@ const VideoPlayer = () => {
   };
 
   const toggleFullscreen = () => {
-    const wrapper = wrapperRef.current;
-    if (!wrapper) return;
+    const video = videoRef.current;
+    if (!video) return;
     if (document.fullscreenElement) {
       document.exitFullscreen();
-    } else if (wrapper.requestFullscreen) {
-      wrapper.requestFullscreen();
+    } else if (video.requestFullscreen) {
+      video.requestFullscreen();
     }
   };
 
@@ -176,13 +176,6 @@ const VideoPlayer = () => {
               <div
                 className="elapsed"
                 style={{ width: `${(currentTime / duration) * 100 || 0}%` }}
-              />
-              <div
-                className="remaining"
-                style={{
-                  left: `${(currentTime / duration) * 100 || 0}%`,
-                  width: `${(1 - currentTime / duration) * 100 || 100}%`,
-                }}
               />
             </div>
           </div>

--- a/src/VideoPlayer.js
+++ b/src/VideoPlayer.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import anime from 'animejs/lib/anime.es.js';
+import { animate } from 'animejs';
 import './VideoPlayer.css';
 
 const BASE_WIDTH = 1840;
@@ -139,11 +139,10 @@ const VideoPlayer = () => {
 
   useEffect(() => {
     if (duration && elapsedRef.current) {
-      progressAnimRef.current = anime({
-        targets: elapsedRef.current,
+      progressAnimRef.current = animate(elapsedRef.current, {
         width: '100%',
         duration: duration * 1000,
-        easing: 'linear',
+        ease: 'linear',
         autoplay: false,
       });
     }


### PR DESCRIPTION
## Summary
- prevent video from stretching full width by limiting player wrapper to its base 1840px width
- give right-side control icons more breathing room with a wider gap
- scale video player with viewport width so it starts resizing below 4K

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b6190fd8c48325b8cc7b9ed08f3f69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive video controls: live current & remaining time, clickable seek bar, Space toggles playback when hovering, fullscreen and AirPlay actions, and a functional volume slider tied to playback.
* **Style**
  * Video now scales with viewport up to a max width while preserving aspect ratio; increased spacing for right-side controls, clickable cursors added, and smoother, transition-driven progress bar rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->